### PR TITLE
CSS Media Rules

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,19 +1,71 @@
-nav {
-  width: 100%;
-  height: 6.6rem;
-  background: #fff;
-  border-top: 2px solid #eee;
-  border-bottom: 2px solid #eee;
-  line-height: 6.3rem;
+@media(max-width: 549px){
+  .front-page {
+    margin-top: 5%;
+  }
+  nav {
+    width: 100%;
+    height: 12.6rem;
+    background: #fff;
+    border-top: 2px solid #eee;
+    border-bottom: 2px solid #eee;
+    line-height: 3.3rem;
+  }
+  nav ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    justify-content: space-between;
+  }
+  .standard-logo {
+    vertical-align:middle;
+    width: 22px;
+    padding: 12px;
+  }
+  .topper{
+    height: 15rem;
+  }
+  .apply-btn {
+    text-align: right;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+  .bottom-img {
+    margin-top: -2rem;
+  }
+}
+@media(min-width: 550px){
+  nav {
+    width: 100%;
+    height: 6.6rem;
+    background: #fff;
+    border-top: 2px solid #eee;
+    border-bottom: 2px solid #eee;
+    line-height: 6.3rem;
+  }
+  
+  nav ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    margin: 0;
+    padding: 0;
+    justify-content: space-between;
+  }
+  .topper {
+    height: 10rem;
+  }
+  .apply-btn {
+    text-align: right;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .bottom-img {
+    margin-top: -12rem;
+  }
 }
 
-nav ul {
-  display: flex;
-  flex-direction: row;
-  margin: 0;
-  padding: 0;
-  justify-content: space-between;
-}
 
 nav ul li {
   list-style: none;
@@ -59,20 +111,8 @@ a.team-title-link:hover{
   margin-top: 25%;
 }
 
-.topper {
-  height: 10rem;
-}
-
 .faq-topper {
   height: 16rem;
-}
-
-.bottom-img {
-  margin-top: -12rem;
-}
-
-.apply-btn {
-  text-align: right;
 }
 
 .space-above-nav {

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,72 +1,16 @@
-@media(max-width: 549px){
-  .front-page {
-    margin-top: 5%;
-  }
-  nav {
-    width: 100%;
-    height: 12.6rem;
-    background: #fff;
-    border-top: 2px solid #eee;
-    border-bottom: 2px solid #eee;
-    line-height: 3.3rem;
-  }
-  nav ul {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    margin: 0;
-    padding: 0;
-    justify-content: space-between;
-  }
-  .standard-logo {
-    vertical-align:middle;
-    width: 22px;
-    padding: 12px;
-  }
-  .topper{
-    height: 15rem;
-  }
-  .apply-btn {
-    text-align: right;
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
-  }
-  .bottom-img {
-    margin-top: -2rem;
-  }
+nav {
+  width: 100%;
+  background: #fff;
+  border-top: 2px solid #eee;
+  border-bottom: 2px solid #eee;
 }
-@media(min-width: 550px){
-  nav {
-    width: 100%;
-    height: 6.6rem;
-    background: #fff;
-    border-top: 2px solid #eee;
-    border-bottom: 2px solid #eee;
-    line-height: 6.3rem;
-  }
-  
-  nav ul {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    margin: 0;
-    padding: 0;
-    justify-content: space-between;
-  }
-  .topper {
-    height: 10rem;
-  }
-  .apply-btn {
-    text-align: right;
-    border-bottom: none;
-    padding-bottom: 0;
-  }
-  .bottom-img {
-    margin-top: -12rem;
-  }
+nav ul {
+  display: flex;
+  flex-direction: row;
+  margin: 0;
+  padding: 0;
+  justify-content: space-between;
 }
-
-
 nav ul li {
   list-style: none;
   flex-grow: 1;
@@ -121,4 +65,60 @@ a.team-title-link:hover{
 
 .no-jobs{
   color: #ff1800;
+}
+.standard-logo {
+  vertical-align:middle;
+  width: 32px;
+}
+@media(max-width: 340px){
+  .standard-logo {
+    width: 15px;
+  }
+}
+@media(max-width: 549px){
+  .front-page {
+    margin-top: 5%;
+  }
+  nav {
+    height: 12.6rem;
+    line-height: 3.3rem;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .standard-logo {
+    padding: 14px;
+  }
+  .topper{
+    height: 15rem;
+  }
+  .apply-btn {
+    text-align: right;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+  .bottom-img {
+    margin-top: -2rem;
+  }
+}
+@media(min-width: 550px){
+  nav {
+    height: 6.6rem;
+    line-height: 6.3rem;
+  }
+  
+  nav ul {
+    flex-wrap: nowrap;
+  }
+  .topper {
+    height: 10rem;
+  }
+  .apply-btn {
+    text-align: right;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .bottom-img {
+    margin-top: -12rem;
+  }
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -68,32 +68,25 @@ a.team-title-link:hover{
 }
 .standard-logo {
   vertical-align:middle;
-  width: 32px;
 }
-@media(max-width: 340px){
+.apply-btn {
+  text-align: right;
+}
+@media(min-width: 320px) and (max-width: 339px){
   .standard-logo {
-    width: 15px;
+    padding: 10px;
   }
-}
-@media(max-width: 549px){
-  .front-page {
-    margin-top: 5%;
+  nav ul {
+    flex-wrap: wrap;
   }
   nav {
     height: 12.6rem;
     line-height: 3.3rem;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
-  .standard-logo {
-    padding: 14px;
-  }
   .topper{
-    height: 15rem;
+    height: 14rem;
   }
   .apply-btn {
-    text-align: right;
     padding-bottom: 5px;
     border-bottom: 1px solid #ff1800;
   }
@@ -101,12 +94,98 @@ a.team-title-link:hover{
     margin-top: -2rem;
   }
 }
+@media(min-width: 340px) and (max-width: 359px){
+  .standard-logo {
+    padding: 12px;
+    width: 32px;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .topper{
+    height: 15rem;
+  }
+  .apply-btn {
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+}
+@media(min-width: 360px) and (max-width: 399px){
+  .standard-logo {
+    padding: 14px;
+    width: 32px;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .topper{
+    height: 16rem;
+  }
+  .apply-btn {
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+}
+@media(min-width: 400px) and (max-width: 449px){
+  .standard-logo {
+    padding: 16px;
+    width: 32px;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .topper{
+    height: 17rem;
+  }
+  .apply-btn {
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+}
+@media(min-width: 450px) and (max-width: 499px){
+  .standard-logo {
+    padding: 19.5px;
+    width: 32px;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .topper{
+    height: 19rem;
+  }
+  .apply-btn {
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+}
+
+@media(min-width: 500px) and (max-width: 549px){
+  .front-page {
+    margin-top: 5%;
+  }
+  nav {
+    height: 16.6rem;
+    line-height: 3.3rem;
+  }
+  nav ul {
+    flex-wrap: wrap;
+  }
+  .standard-logo {
+    padding: 25px;
+  }
+  .topper{
+    height: 20rem;
+  }
+  .apply-btn {
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ff1800;
+  }
+}
 @media(min-width: 550px){
   nav {
     height: 6.6rem;
     line-height: 6.3rem;
-  }
-  
+  } 
   nav ul {
     flex-wrap: nowrap;
   }

--- a/css/custom.css
+++ b/css/custom.css
@@ -7,6 +7,7 @@ nav {
 nav ul {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   margin: 0;
   padding: 0;
   justify-content: space-between;
@@ -71,13 +72,12 @@ a.team-title-link:hover{
 }
 .apply-btn {
   text-align: right;
+  padding-bottom: 5px;
+  border-bottom: 1px solid #ff1800;
 }
 @media(min-width: 320px) and (max-width: 339px){
   .standard-logo {
     padding: 10px;
-  }
-  nav ul {
-    flex-wrap: wrap;
   }
   nav {
     height: 12.6rem;
@@ -85,10 +85,6 @@ a.team-title-link:hover{
   }
   .topper{
     height: 14rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
   .bottom-img {
     margin-top: -2rem;
@@ -99,15 +95,8 @@ a.team-title-link:hover{
     padding: 12px;
     width: 32px;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
   .topper{
     height: 15rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
 }
 @media(min-width: 360px) and (max-width: 399px){
@@ -115,15 +104,8 @@ a.team-title-link:hover{
     padding: 14px;
     width: 32px;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
   .topper{
     height: 16rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
 }
 @media(min-width: 400px) and (max-width: 449px){
@@ -131,15 +113,8 @@ a.team-title-link:hover{
     padding: 16px;
     width: 32px;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
   .topper{
     height: 17rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
 }
 @media(min-width: 450px) and (max-width: 499px){
@@ -147,15 +122,8 @@ a.team-title-link:hover{
     padding: 19.5px;
     width: 32px;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
   .topper{
     height: 19rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
 }
 
@@ -167,18 +135,11 @@ a.team-title-link:hover{
     height: 16.6rem;
     line-height: 3.3rem;
   }
-  nav ul {
-    flex-wrap: wrap;
-  }
   .standard-logo {
     padding: 25px;
   }
   .topper{
     height: 20rem;
-  }
-  .apply-btn {
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ff1800;
   }
 }
 @media(min-width: 550px){

--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -41,6 +41,10 @@
   float: left;
   box-sizing: border-box; }
 
+.five.columns{
+  margin-top: 30px;
+}
+
 /* For devices larger than 400px */
 @media (min-width: 400px) {
   .container {
@@ -64,7 +68,7 @@
   .two.columns                    { width: 13.3333333333%; }
   .three.columns                  { width: 22%;            }
   .four.columns                   { width: 30.6666666667%; }
-  .five.columns                   { width: 39.3333333333%; }
+  .five.columns                   { width: 39.3333333333%; margin-top: 0;}
   .six.columns                    { width: 48%;            }
   .seven.columns                  { width: 56.6666666667%; }
   .eight.columns                  { width: 65.3333333333%; }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <meta charset="utf-8">
     <title>Formula 1 Jobs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A collection of available jobs at all the Formula 1 teams.Fast, up-to-date and open-source.">
     <meta name="author" content="aydwi">
 


### PR DESCRIPTION
I altered some of the CSS rules for screen widths smaller than 550 pixels. The main change is with the sticky nav bar; it would bunch up all the logos on smaller screens. Instead, it now wraps the nav bar to make two rows of logos.

Added a border to the bottom of each job posting to better distinguish each job post on smaller screens as the apply button is no longer in line with the text below 550 pixels. Should definitely be changed in the future.

Tell me what you think!